### PR TITLE
After import rename each Armature using the filename

### DIFF
--- a/mixamoroot.py
+++ b/mixamoroot.py
@@ -283,6 +283,12 @@ def import_armature(filepath, root_bone_name="Root", hip_bone_name="mixamorig:Hi
     imported_actions = [x.animation_data.action for x in imported_objects if x.animation_data]
     print("[Mixamo Root] Now importing: " + str(filepath))
     imported_actions[0].name = Path(filepath).resolve().stem # Only reads the first animation associated with an imported armature
+    imported_armatures = [obj for obj in imported_objects if obj.type == 'ARMATURE']
+
+
+    if imported_armatures:
+        armature = imported_armatures[0]
+        armature.name = Path(filepath).resolve().stem
     
     if insert_root:
         add_root_bone(root_bone_name, hip_bone_name, remove_prefix, name_prefix)

--- a/mixamoroot.py
+++ b/mixamoroot.py
@@ -281,7 +281,7 @@ def import_armature(filepath, root_bone_name="Root", hip_bone_name="mixamorig:Hi
     
     imported_objects = set(bpy.context.scene.objects) - old_objs
     imported_actions = [x.animation_data.action for x in imported_objects if x.animation_data]
-    print("[Mixamo Root] Now importing: " + str(filepath))
+    print("[Mixamo Root] Now importing: " + str(filepath), filepath)
     imported_actions[0].name = Path(filepath).resolve().stem # Only reads the first animation associated with an imported armature
     imported_armatures = [obj for obj in imported_objects if obj.type == 'ARMATURE']
 
@@ -345,7 +345,7 @@ def get_all_anims(source_dir, root_bone_name="Root", hip_bone_name="mixamorig:Hi
     for file in files:
         print("file: " + str(file))
         try:
-            filepath = source_dir+"/"+file
+            filepath = os.path.join(source_dir, file)
             import_armature(filepath, root_bone_name, hip_bone_name, remove_prefix, name_prefix, insert_root, delete_armatures)
             imported_objects = set(bpy.context.scene.objects) - old_objs
             if delete_armatures and num_files > 1:


### PR DESCRIPTION
Fixes the imports so that the filename of the FBX is the name of the object.

![Screenshot from 2024-04-04 21-42-24](https://github.com/RichardPerry/Mixamo-Root/assets/8354329/9bf477ec-b6d2-4a8f-9a8b-e595efab383a)
