### PR TITLE
#4 fix root bone size to proportionate

### DIFF
--- a/mixamoroot.py
+++ b/mixamoroot.py
@@ -293,7 +293,7 @@ def add_root_bone(root_bone_name="Root", hip_bone_name="mixamorig:Hips", remove_
     bpy.ops.object.mode_set(mode='EDIT')
 
     root_bone = armature.data.edit_bones.new(name_prefix + root_bone_name)
-    root_bone.tail.y = 30
+    root_bone.tail.y = 0.3
 
     armature.data.edit_bones[hip_bone_name].parent = armature.data.edit_bones[name_prefix + root_bone_name]
     bpy.ops.object.mode_set(mode='OBJECT')

--- a/mixamoroot.py
+++ b/mixamoroot.py
@@ -292,8 +292,15 @@ def add_root_bone(root_bone_name="Root", hip_bone_name="mixamorig:Hips", remove_
     armature = bpy.context.selected_objects[0]
     bpy.ops.object.mode_set(mode='EDIT')
 
+    # Get the bounding box dimensions
+    bounding_box = armature.bound_box
+    fixed_ratio = 0.3
+    armature_height = bounding_box[6][2] - bounding_box[0][2]  # Index 2 corresponds to the z-dimension
+    root_bone_length = armature_height * fixed_ratio
+
     root_bone = armature.data.edit_bones.new(name_prefix + root_bone_name)
-    root_bone.tail.y = 0.3
+    root_bone.tail.y = root_bone_length
+
 
     armature.data.edit_bones[hip_bone_name].parent = armature.data.edit_bones[name_prefix + root_bone_name]
     bpy.ops.object.mode_set(mode='OBJECT')


### PR DESCRIPTION
Hypothesizing that the variability in character heights when imported into Miximo for rigging, I encountered an issue with the output root bone size being too large #4  smaller models. To address this, I experimented with obtaining animations for both taller and smaller models from Mixamo.

Subsequently, I adjusted the desired bone size to approximately 30% of the model's height. However, as a newcomer to Godot, I'm uncertain about the potential impact on animations. Therefore, testing is necessary to ensure compatibility and performance. This code is a best guess solution for now.


Please note that the rotated bone is another issue I am going to try and figure out.

![Screenshot from 2024-04-04 21-45-38](https://github.com/RichardPerry/Mixamo-Root/assets/8354329/cb291247-7bd9-4317-9872-c245fda4ea08)
